### PR TITLE
Add `working-directory` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ GitHub Action to split test files based on JUnit XML reports, as [`circleci test
 - `total`
     - Total count of test nodes.
     - e.g. `4`
+- `working-directory` (optional, default: `.`)
+    - Working directory to run the action.
+    - e.g. `path/to/app`
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   total:
     description: Total count of test nodes.
     required: true
+  working-directory:
+    description: Working directory to run the action.
+    required: false
+    default: .
 outputs:
   paths:
     description: Paths of test files to run.
@@ -24,6 +28,7 @@ runs:
         curl -L --output split-test https://github.com/mtsmfm/split-test/releases/download/v1.0.0/split-test-x86_64-unknown-linux-gnu
         chmod +x split-test
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
     - id: split-tests
       run: |
         PATHS=$(
@@ -38,8 +43,10 @@ runs:
         echo "paths=${PATHS}"
         echo "paths=${PATHS}" >> $GITHUB_OUTPUT
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
     - run: rm split-test
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 branding:
   color: green
   icon: grid


### PR DESCRIPTION
In response to #4, it is now possible to specify the working directory. In my situation, this seems to be working well. How about you?

- Resolves #4