### PR TITLE
Change split-test version from 1.0.0 to 1.1.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
   using: composite
   steps:
     - run: |
-        curl -L --output split-test https://github.com/mtsmfm/split-test/releases/download/v1.0.0/split-test-x86_64-unknown-linux-gnu
+        curl -L --output split-test https://github.com/mtsmfm/split-test/releases/download/v1.1.0/split-test-x86_64-unknown-linux-gnu
         chmod +x split-test
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
That resolves issue:

- https://github.com/mtsmfm/split-test/issues/10

so that test won't fail early.